### PR TITLE
feat: custom search for users

### DIFF
--- a/src/main/java/br/com/teamdevs/agilekanban/controllers/UsersController.java
+++ b/src/main/java/br/com/teamdevs/agilekanban/controllers/UsersController.java
@@ -1,5 +1,7 @@
 package br.com.teamdevs.agilekanban.controllers;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import br.com.teamdevs.agilekanban.dto.UserResponseDTO;
@@ -123,5 +126,25 @@ public class UsersController {
     public ResponseEntity<Void> remove(@PathVariable String id) {
         userService.remove(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(
+        summary = "",
+        description = ""
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "", description = ""),
+        @ApiResponse(responseCode = "", description = "")
+    })
+    @GetMapping("/users/search")
+    public ResponseEntity<UserResponseDTO> customSearch(
+        @RequestParam(required = false) String username, 
+        @RequestParam(required = false) String email
+        ) {
+            List<User> data = userService.search(username, email);
+
+            UserResponseDTO response = new UserResponseDTO(data);
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/br/com/teamdevs/agilekanban/repository/UserRepository.java
+++ b/src/main/java/br/com/teamdevs/agilekanban/repository/UserRepository.java
@@ -3,6 +3,7 @@ package br.com.teamdevs.agilekanban.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -19,7 +20,7 @@ public class UserRepository {
     private final static String COLLECTION_NAME = "allData";
     private final static String UNWIND_USERS = "users";
 
-    private MongoTemplate mongoTemplate;
+    private final MongoTemplate mongoTemplate;
 
     public UserRepository(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
@@ -63,6 +64,28 @@ public class UserRepository {
     
         mongoTemplate.findAndModify(query, update, User.class);
         return mongoTemplate.findById(new ObjectId(id), User.class);
+    } // PADRÃO
+
+    public List<User> search(String username, String email) {
+        Criteria criteria = new Criteria();
+        
+        boolean isUsernameEmpty = StringUtils.isEmpty(username);
+        boolean isEmailEmpty = StringUtils.isEmpty(email);
+        
+        if (isUsernameEmpty && isEmailEmpty) {
+            return null;
+        }
+        
+        if (!isUsernameEmpty) {
+            criteria = criteria.and("username").regex("^" + username, "i");
+        }
+        if (!isEmailEmpty) {
+            criteria = criteria.and("email").is(email);
+        }
+        
+        Query query = new Query(criteria);
+        
+        return mongoTemplate.find(query, User.class);
     }
 
     public void delete(String id) {

--- a/src/main/java/br/com/teamdevs/agilekanban/services/UserService.java
+++ b/src/main/java/br/com/teamdevs/agilekanban/services/UserService.java
@@ -48,4 +48,14 @@ public class UserService {
     public void remove(String id) {
         repository.delete(id);
     }
+
+    public List<User> search(String username, String email) {
+        List<User> data = repository.search(username, email);
+
+        if (data == null) {
+            throw new CustomException(HttpStatus.NOT_FOUND.value(), "User not found.");
+        }
+
+        return data;
+    }
 }


### PR DESCRIPTION
Introduz a funcionalidade de busca por prefixo no campo username ou email dos usuários. Esta nova operação de busca permite aos clientes da API recuperar uma lista de usuários cujos nomes de usuário começam com um determinado prefixo, facilitando a localização de usuários em situações onde apenas uma parte inicial do nome de usuário é conhecida.
![Screenshot 2024-01-22 at 09 10 46](https://github.com/AF2B/agile-kanban/assets/81587964/158e443f-fcd5-4ab2-96f9-e3dbdb5552c7)
